### PR TITLE
Criar crossref para referência inproceeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ## [Unreleased]
 
 ### Added
-
+- We added a feature that automatically creates a proceeding entry when an inproceeding entry is created (the proceeding is created when the BiBTeX Source is edited)
 - We added a field showing the BibTeX/biblatex source for added and deleted entries in the "External Changes Resolver" dialog. [#9509](https://github.com/JabRef/jabref/issues/9509)
 - We added a search history list in the search field's right click menu. [#7906](https://github.com/JabRef/jabref/issues/7906)
 - We added a full text fetcher for IACR eprints. [#9651](https://github.com/JabRef/jabref/pull/9651)

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -123,6 +123,7 @@ public class SourceTab extends EntryEditorTab {
 
     /**
      * Create a proceedings crossref to an inproceedings entry
+     *
      * the following fields are extracted:
      *         Address
      *         conference-year
@@ -134,11 +135,11 @@ public class SourceTab extends EntryEditorTab {
      *         title
      * @param inproceedings inproceedings entry to extract crossref
      */
-    private void createProceedingCrossref(BibEntry inproceedings){
+    protected void createProceedingCrossref(BibEntry inproceedings){
         BibEntry newBib = new BibEntry(StandardEntryType.Proceedings);
 
         // if the inproceedings dont have any field, just return without creating proceedings
-        if(inproceedings.isEmpty()){
+        if(inproceedings == null ||inproceedings.isEmpty()){
             return;
         }
 
@@ -170,18 +171,20 @@ public class SourceTab extends EntryEditorTab {
             tag = tag + inproceedings.getField(StandardField.TITLE).get();
             newBib.setField(StandardField.TITLE, inproceedings.getField(StandardField.TITLE).get());
         }
+
+        // if after all checks, the new entry doesnt have any field to extract, do not create a new entry
+        if(newBib.isEmpty()){
+            return;
+        }
         BibDatabase database = this.stateManager.getActiveDatabase().get().getDatabase();
 
-        tag = tag.replace(" ", "_");
+        tag = tag.replace(" ", "_"); // remove the blank spaces in key name
         // check if the new entry already exists
         if(database.getNumberOfCitationKeyOccurrences(tag) == 0){
             newBib.setField(InternalField.KEY_FIELD, tag);
             database.insertEntry(newBib);
             inproceedings.setField(StandardField.CROSSREF, tag);
         }
-
-
-
     }
 
     private void highlightSearchPattern() {

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -164,7 +164,6 @@ public class SourceTab extends EntryEditorTab {
             newBib.setField(StandardField.YEAR, inproceedings.getField(StandardField.YEAR).get());
         }
         if (inproceedings.getField(StandardField.BOOKTITLE).isPresent()){
-            tag = tag + inproceedings.getField(StandardField.BOOKTITLE).get();
             newBib.setField(StandardField.BOOKTITLE, inproceedings.getField(StandardField.BOOKTITLE).get());
         }
         if (inproceedings.getField(StandardField.TITLE).isPresent()){

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -284,7 +284,6 @@ public class SourceTab extends EntryEditorTab {
                     createProceedingCrossref(this.currentEntry);
                 }
             }
-            // TODO: chamada precisa ser feita aqui, pq antes disso o valor não foi atualizado ainda
 
         });
         VirtualizedScrollPane<CodeArea> scrollableCodeArea = new VirtualizedScrollPane<>(codeArea);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -115,13 +115,6 @@ public class SourceTab extends EntryEditorTab {
         this.stateManager = stateManager;
         this.keyBindingRepository = keyBindingRepository;
 
-//        this.setOnSelectionChanged( e -> {
-//            if(!this.isSelected()){
-//                // enter here when other tab is selected
-//                createProceedingCrossref(this.currentEntry);
-//            }
-//        });
-
         stateManager.activeSearchQueryProperty().addListener((observable, oldValue, newValue) -> {
             searchHighlightPattern = newValue.flatMap(SearchQuery::getPatternForWords);
             highlightSearchPattern();

--- a/src/test/java/org/jabref/gui/entryeditor/SourceTabGenerateCrossrefTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/SourceTabGenerateCrossrefTest.java
@@ -1,0 +1,161 @@
+package org.jabref.gui.entryeditor;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.keyboard.KeyBindingRepository;
+import org.jabref.gui.undo.CountingUndoManager;
+import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.testutils.category.GUITest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+@GUITest
+@ExtendWith(ApplicationExtension.class)
+public class SourceTabGenerateCrossrefTest {
+
+    private SourceTab sourceTab;
+    private BibDatabase database;
+
+
+    @BeforeEach
+    public void mockSourceTab(){
+        database = new BibDatabase();
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(database);
+        StateManager stateManager = new StateManager();
+        stateManager.setActiveDatabase(bibDatabaseContext);
+
+        KeyBindingRepository keyBindingRepository = new KeyBindingRepository(Collections.emptyList(), Collections.emptyList());
+
+        sourceTab = new SourceTab(
+                new BibDatabaseContext(),
+                new CountingUndoManager(),
+                mock(FieldPreferences.class),
+                mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                new DummyFileUpdateMonitor(),
+                mock(DialogService.class),
+                stateManager,
+                keyBindingRepository);
+    }
+
+
+    @Test
+    void testCreateCrossref(){
+        BibEntry inproceedings = createInproceedingsWithUtilFields();
+
+        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.BOOKTITLE).get() + inproceedings.getField(StandardField.TITLE).get();
+        keyCreatedProceeding = keyCreatedProceeding.replace(" ", "_");
+
+        database.insertEntry(inproceedings);
+
+        sourceTab.createProceedingCrossref(inproceedings);
+
+        BibEntry expectedEntry = createExpectedProceedings(keyCreatedProceeding);
+
+        if(database.getEntryByCitationKey(keyCreatedProceeding).isPresent()){
+            BibEntry createdEntry = database.getEntryByCitationKey(keyCreatedProceeding).get();
+
+            assertEquals(expectedEntry, createdEntry);
+        }else{
+            fail("Entrada não foi criada com sucesso");
+        }
+    }
+
+    @Test
+    void testTryCreateProceedingWithDuplicateValue(){
+        BibEntry inproceedings = createInproceedingsWithUtilFields();
+
+        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.BOOKTITLE).get() + inproceedings.getField(StandardField.TITLE).get();
+        keyCreatedProceeding = keyCreatedProceeding.replace(" ", "_");
+
+        BibEntry proceedings = createExpectedProceedings(keyCreatedProceeding);
+        database.insertEntries(inproceedings, proceedings);
+
+        sourceTab.createProceedingCrossref(inproceedings);
+
+        // check if exists only 2 entries in database(inproceedings and proceedings that we already add to test)
+        assertEquals(database.getEntryCount(), 2);
+    }
+
+    @Test
+    void testCreateInproceedingsEmpty(){
+        BibEntry inproceedings = new BibEntry(StandardEntryType.InProceedings);
+
+        database.insertEntry(inproceedings);
+
+        sourceTab.createProceedingCrossref(inproceedings);
+
+        // verify if exists only one entry(the empty inproceedings entry)
+        assertEquals(database.getEntryCount(), 1);
+    }
+
+    @Test
+    void testCreateInproceedingsWithoutUtilFields(){
+
+        BibEntry inproceedings = new BibEntry(StandardEntryType.InProceedings);
+        inproceedings.setField(StandardField.AUTHOR, "Ferber, Jacques");
+        inproceedings.setField(StandardField.ISBN, "1-234-5678-9");
+
+        database.insertEntry(inproceedings);
+
+        sourceTab.createProceedingCrossref(inproceedings);
+
+        // verify if exists only one entry(the inproceedings entry without util fields to extract)
+        assertEquals(database.getEntryCount(), 1);
+
+    }
+
+
+    private static BibEntry createExpectedProceedings(String keyCreatedProceeding) {
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Proceedings);
+        expectedEntry.setField(StandardField.ADDRESS, "Frankfurt");
+        expectedEntry.setField(StandardField.ORGANIZATION, "INTERNATIONAL STUDY CONFERENCE ON CLASSIFICATION RESEARCH");
+        expectedEntry.setField(StandardField.PUBLISHER, "Indeks Verlag");
+        expectedEntry.setField(StandardField.TITLE, "Repensando os conceitos no estudo de classificacão");
+        expectedEntry.setField(StandardField.BOOKTITLE, "Proceedings...");
+        expectedEntry.setField(StandardField.YEAR, "1982");
+        expectedEntry.setField(new UnknownField("conference-year"), "1982");
+        expectedEntry.setField(new UnknownField("conference-location"), "Augsburg. Universal Classification: Subject analysis and ordering systems");
+        expectedEntry.setField(InternalField.KEY_FIELD, keyCreatedProceeding);
+        return expectedEntry;
+    }
+
+    private static BibEntry createInproceedingsWithUtilFields() {
+        BibEntry inproceedings = new BibEntry(StandardEntryType.InProceedings);
+        inproceedings.setField(StandardField.AUTHOR, "Kaula, P. N");
+        inproceedings.setField(StandardField.ADDRESS, "Frankfurt");
+        inproceedings.setField(StandardField.ORGANIZATION, "INTERNATIONAL STUDY CONFERENCE ON CLASSIFICATION RESEARCH");
+        inproceedings.setField(StandardField.PUBLISHER, "Indeks Verlag");
+        inproceedings.setField(StandardField.TITLE, "Repensando os conceitos no estudo de classificacão");
+        inproceedings.setField(StandardField.BOOKTITLE, "Proceedings...");
+        inproceedings.setField(StandardField.YEAR, "1982");
+        inproceedings.setField(InternalField.KEY_FIELD, "chave-teste");
+        inproceedings.setField(new UnknownField("conference-year"), "1982");
+        inproceedings.setField(new UnknownField("conference-location"), "Augsburg. Universal Classification: Subject analysis and ordering systems");
+        inproceedings.setField(new UnknownField("conference-number"), "4");
+        return inproceedings;
+    }
+
+
+
+
+
+
+}

--- a/src/test/java/org/jabref/gui/entryeditor/SourceTabGenerateCrossrefTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/SourceTabGenerateCrossrefTest.java
@@ -60,7 +60,7 @@ public class SourceTabGenerateCrossrefTest {
     void testCreateCrossref(){
         BibEntry inproceedings = createInproceedingsWithUtilFields();
 
-        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.BOOKTITLE).get() + inproceedings.getField(StandardField.TITLE).get();
+        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.TITLE).get();
         keyCreatedProceeding = keyCreatedProceeding.replace(" ", "_");
 
         database.insertEntry(inproceedings);
@@ -82,7 +82,7 @@ public class SourceTabGenerateCrossrefTest {
     void testTryCreateProceedingWithDuplicateValue(){
         BibEntry inproceedings = createInproceedingsWithUtilFields();
 
-        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.BOOKTITLE).get() + inproceedings.getField(StandardField.TITLE).get();
+        String keyCreatedProceeding = "proc-" + inproceedings.getField(StandardField.TITLE).get();
         keyCreatedProceeding = keyCreatedProceeding.replace(" ", "_");
 
         BibEntry proceedings = createExpectedProceedings(keyCreatedProceeding);


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

fix tuchinski#9

Cria uma feature que ao adicionar uma entrada do tipo Inproceeding, gera automaticamente uma entrada do tipo Proceeding, extraindo os seguintes campos:

- Address
- conference-year
- Conference-location
- organization
- publisher
- Year
- booktitle
- title

Criando inproceedings
<img width="1677" alt="image" src="https://github.com/learningspace-utfpr-cm/jabref-engsw2-2023-1/assets/18310704/6c03b024-122e-4bab-bc2c-51ec966912bb">

Inproceeding criado com a entrada proceeding gerada
<img width="1675" alt="image" src="https://github.com/learningspace-utfpr-cm/jabref-engsw2-2023-1/assets/18310704/201ac299-dc6d-40ff-b275-f67ab05b91f9">




### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
